### PR TITLE
Allow ordering JS/CSS resources

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2023 Impractical Labs, LLC
+Copyright (c) 2025 Impractical Labs, LLC
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/css.go
+++ b/css.go
@@ -2,75 +2,397 @@ package temple
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"html/template"
+	"errors"
+	"io/fs"
+	"maps"
+	"strings"
 )
+
+var (
+	// ErrCSSInlineTemplatePathNotSet is returned when the TemplatePath
+	// property on a CSSInline is not set, which isn't valid. The
+	// TemplatePath controls what CSS to embed, so it should never be
+	// omitted.
+	ErrCSSInlineTemplatePathNotSet = errors.New("CSSInline TemplatePath must be set")
+)
+
+// cssResource is an abstraction over CSSLink and CSSInline.
+type cssResource interface {
+	// getCSS returns the CSS template string to render for the link or
+	// style block.
+	getCSS(dir fs.FS) (string, error)
+
+	// getKey returns a unique identifier for the template, used when
+	// caching it.
+	getKey() string
+
+	// equal should return true if the passed cssResource is considered
+	// equivalent to the implementing cssResource. This is used when
+	// deduplicating resources.
+	equal(cssResource) bool
+}
+
+// CSSRenderData holds the information passed to the template when rendering
+// the template for a [CSSInline] or [CSSLink].
+type CSSRenderData[SiteType Site, PageType Renderable] struct {
+	// CSS is the CSSInline struct being rendered. It may be empty if this
+	// data is for a CSSLink instead.
+	CSS CSSInline
+
+	// CSSLink is the CSSLink struct being rendered. It may be empty if
+	// this data is for a CSSInline instead.
+	CSSLink CSSLink
+
+	// Site is the caller-defined site type, used for including globals.
+	Site SiteType
+
+	// Page is the specific page the CSS is being rendered into.
+	Page PageType
+}
+
+// CSSInline holds the necessary information to embed CSS directly into a
+// page's HTML output, inside a <style> tag.
+//
+// The TemplatePath should point to a template containing the CSS to render.
+// The template can use any of the data in the [CSSRenderData]. The <style> tag
+// should not be included; it will be generated from the rest of the
+// properties.
+//
+// temple may, but is not guaranteed to, merge <style> blocks it identifies as
+// mergeable. At the moment, those merge semantics are that all properties
+// except the relation calculators are identical, but that logic is subject to
+// change. If it is important that a <style> block not be merged into any other
+// <style> block, set DisableElementMerge to true.
+type CSSInline struct {
+	// TemplatePath is the path, relative to the Site's TemplateDir, to the
+	// template that should be rendered to get the contents of the CSS
+	// <style> block. The template should not include the <style> tags. A
+	// CSSRenderData value will be passed as the template data, with the
+	// CSSInline property set to this value.
+	TemplatePath string
+
+	// Blocking is the value of the blocking attribute for the <style> tag
+	// that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#blocking
+	// for more information.
+	Blocking string
+
+	// Media is the value of the media attribute for the <style> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#media
+	// for more information.
+	Media string
+
+	// Nonce is the value of the nonce attribute for the <style> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#nonce
+	// for more information.
+	Nonce string
+
+	// Title is the value of the title attribute for the <style> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/style#title
+	// for more information.
+	Title string
+
+	// Attrs holds any additional non-standard or unsupported attributes
+	// that should be set on the <style> tag that will be generated.
+	Attrs map[string]string
+
+	// DisableElementMerge, when set to true, prevents a <style> block from
+	// being merged with any other <style> block.
+	DisableElementMerge bool
+
+	// CSSLinkRelationCalculator can be used to control how this <link> tag
+	// gets rendered in relation to any other CSS <link> tag. If the
+	// function returns ResourceRelationshipAfter, this <link> tag will
+	// always come after the other <link> tag in the HTML document. If the
+	// function returns ResourceRelationshipBefore, this <link> tag will
+	// always come before the other <link> tag in the HTML document. If the
+	// function returns ResourceRelationshipNeutral, no guarantees are made
+	// about where the CSS resources will appear relative to each other in
+	// the HTML document.
+	//
+	// If this <link> tag has no requirements about its positioning
+	// relative to other CSS resources, just let this property be nil.
+	CSSLinkRelationCalculator func(context.Context, CSSLink) ResourceRelationship
+
+	// CSSInlineRelationCalculator can be used to control how this <style>
+	// block gets rendered in relation to any other <style> block. If the
+	// function returns ResourceRelationshipAfter, this <style> block will
+	// always come after the other <style> block in the HTML document. If
+	// the function returns ResourceRelationshipBefore, this <style> block
+	// will always come before the other <style> block in the HTML
+	// document. If the function returns ResourceRelationshipNeutral, no
+	// guarantees are made about where the CSS resources will appear
+	// relative to each other in the HTML document.
+	//
+	// If this <style> block has no requirements about its positioning
+	// relative to other CSS resources, just let this property be nil.
+	CSSInlineRelationCalculator func(context.Context, CSSInline) ResourceRelationship
+}
+
+// equal returns true if block and other should be considered equal. The
+// largest consequence of returning true is that only one will be rendered to
+// the page.
+func (block CSSInline) equal(other cssResource) bool {
+	comp, ok := other.(CSSInline)
+	if !ok {
+		return false
+	}
+	if block.TemplatePath != comp.TemplatePath {
+		return false
+	}
+	if block.Blocking != comp.Blocking {
+		return false
+	}
+	if block.Media != comp.Media {
+		return false
+	}
+	if block.Nonce != comp.Nonce {
+		return false
+	}
+	if block.Title != comp.Title {
+		return false
+	}
+	if !maps.Equal(block.Attrs, comp.Attrs) {
+		return false
+	}
+	if block.DisableElementMerge != comp.DisableElementMerge {
+		return false
+	}
+	return true
+}
+
+// getCSS returns the string to include in the CSS output, using the passed
+// fs.FS to load the template path.
+func (block CSSInline) getCSS(dir fs.FS) (string, error) {
+	if strings.TrimSpace(block.TemplatePath) == "" {
+		return "", ErrCSSInlineTemplatePathNotSet
+	}
+	contents, err := fs.ReadFile(dir, block.TemplatePath)
+	if err != nil {
+		return "", err
+	}
+	return `<style{{ if .CSS.Blocking }} blocking="{{ .CSS.Blocking }}"{{ end }}{{ if .CSS.Media }} media="{{ .CSS.Media }}"{{ end }}{{ if .CSS.Nonce }} nonce="{{ .CSS.Nonce }}"{{ end }}{{ if .CSS.Title }} title="{{ .CSS.Title }}"{{ end }}{{ range $key, $val := .CSS.Attrs }} {{ $key }}="{{ $val }}"{{ end }}>
+` + string(contents) + `
+</style>`, nil
+}
+
+// getKey returns a cache key for the template for this tag. The cache key
+// should be unique to the template literal, without regard to the template
+// data.
+func (block CSSInline) getKey() string {
+	return block.TemplatePath
+}
+
+// CSSLink holds the necessary information to include CSS in a page's HTML
+// output as a <link>, which downloads the CSS file from another URL.
+//
+// The Href should point to the URL to load the CSS file from.
+type CSSLink struct {
+	// Href is the URL to load the CSS from. It will be used verbatim as
+	// the <link> element's href attribute. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#href
+	// for more information.
+	Href string
+
+	// Rel is the value of the rel attribute for the <link> tag that will be
+	// generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel
+	// for more information.
+	Rel string
+
+	// As is the value of the as attribute for the <link> tag that will be
+	// generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#as
+	// for more information.
+	As string
+
+	// Blocking is the value of the blocking attribute for the <link> tag
+	// that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#blocking
+	// for more information.
+	Blocking string
+
+	// CrossOrigin is the value of the crossorigin attribute for the <link>
+	// tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/crossorigin
+	// for more information.
+	CrossOrigin string
+
+	// Disabled indicates whether to include the disabled attribute in the
+	// <link> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#disabled
+	// for more information.
+	Disabled bool
+
+	// FetchPriority is the value of the fetchpriority attribute for the
+	// <link> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#fetchpriority
+	// for more information.
+	FetchPriority string
+
+	// Integrity is the value of the integrity attribute for the <link> tag
+	// that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#integrity
+	// for more information.
+	Integrity string
+
+	// Media is the value of the media attribute for the <link> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#media
+	// for more information.
+	Media string
+
+	// ReferrerPolicy is the value of the referrerpolicy attribute for the
+	// <link> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#referrerpolicy
+	// for more information.
+	ReferrerPolicy string
+
+	// Title is the value of the title attribute for the <link> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#title
+	// for more information.
+	Title string
+
+	// Type is the value of the type attribute for the <link> tag that will
+	// be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/link#type
+	// for more information.
+	Type string
+
+	// Attrs holds any additional non-standard or unsupported attributes
+	// that should be set on the <link> tag that will be generated.
+	Attrs map[string]string
+
+	// CSSLinkRelationCalculator can be used to control how this <link> tag
+	// gets rendered in relation to any other CSS link tag. If the function
+	// returns ResourceRelationshipAfter, this <link> tag will always come
+	// after the other link in the HTML document. If the function returns
+	// ResourceRelationshipBefore, this <link> tag will always come before
+	// the other link in the HTML document. If the function returns
+	// ResourceRelationshipNeutral, no guarantees are made about where the
+	// CSS resources will appear relative to each other in the HTML
+	// document.
+	//
+	// If this <link> tag has no requirements about its positioning
+	// relative to other CSS resources, just let this property be nil.
+	CSSLinkRelationCalculator func(context.Context, CSSLink) ResourceRelationship
+
+	// CSSInlineRelationCalculator can be used to control how this <link>
+	// tag gets rendered in relation to any <style> block. If the function
+	// returns ResourceRelationshipAfter, this <link> tag will always come
+	// after the <style> block in the HTML document. If the function
+	// returns ResourceRelationshipBefore, this <link> tag will always come
+	// before the <style> block in the HTML document. If the function
+	// returns ResourceRelationshipNeutral, no guarantees are made about
+	// where the CSS resources will appear relative to each other in the
+	// HTML document.
+	//
+	// If this <link> tag has no requirements about its positioning
+	// relative to other CSS resources, just let this property be nil.
+	CSSInlineRelationCalculator func(context.Context, CSSInline) ResourceRelationship
+
+	// TemplatePath is the path, relative to the Site's TemplateDir, to the
+	// template that should be rendered to construct the <link> tag from
+	// this struct. If left empty, the default template will be used, but
+	// it can be specified to override the template if desired. A
+	// CSSRenderData will be passed to the template with the CSSLink
+	// property set.
+	TemplatePath string
+}
+
+// equal returns true if tag and other should be considered equal. The largest
+// consequence of returning true is that only one will be rendered to the page.
+func (tag CSSLink) equal(other cssResource) bool {
+	comp, ok := other.(CSSLink)
+	if !ok {
+		return false
+	}
+	if tag.Href != comp.Href {
+		return false
+	}
+	if tag.Rel != comp.Rel {
+		return false
+	}
+	if tag.As != comp.As {
+		return false
+	}
+	if tag.Blocking != comp.Blocking {
+		return false
+	}
+	if tag.CrossOrigin != comp.CrossOrigin {
+		return false
+	}
+	if tag.Disabled != comp.Disabled {
+		return false
+	}
+	if tag.FetchPriority != comp.FetchPriority {
+		return false
+	}
+	if tag.Integrity != comp.Integrity {
+		return false
+	}
+	if tag.Media != comp.Media {
+		return false
+	}
+	if tag.ReferrerPolicy != comp.ReferrerPolicy {
+		return false
+	}
+	if tag.Title != comp.Title {
+		return false
+	}
+	if tag.Type != comp.Type {
+		return false
+	}
+	if !maps.Equal(tag.Attrs, comp.Attrs) {
+		return false
+	}
+	if tag.TemplatePath != comp.TemplatePath {
+		return false
+	}
+	return true
+}
+
+// getCSS returns the string to include in the CSS output, using the passed
+// fs.FS to load the template path, if tag.TemplatePath is set.
+func (tag CSSLink) getCSS(dir fs.FS) (string, error) {
+	if tag.TemplatePath != "" {
+		contents, err := fs.ReadFile(dir, tag.TemplatePath)
+		if err != nil {
+			return "", err
+		}
+		return string(contents), nil
+	}
+	return `<link{{ if .CSSLink.Href}} href="{{ .CSSLink.Href }}"{{ end }}{{ if .CSSLink.Rel }} rel="{{ .CSSLink.Rel }}"{{ end }}{{ if .CSSLink.As }} as="{{ .CSSLink.As }}"{{ end }}{{ if .CSSLink.Blocking }} blocking="{{ .CSSLink.Blocking }}"{{ end }}{{ if .CSSLink.CrossOrigin }} crossorigin="{{ .CSSLink.CrossOrigin }}"{{ end }}{{ if .CSSLink.Disabled }} disabled{{ end }}{{ if .CSSLink.FetchPriority }} fetchpriority="{{ .CSSLink.FetchPriority }}"{{ end }}{{ if .CSSLink.Integrity }} integrity="{{ .CSSLink.Integrity }}"{{ end }}{{ if .CSSLink.Media }}media="{{ .CSSLink.Media }}"{{ end }}{{ if .CSSLink.ReferrerPolicy }} referrerpolicy="{{ .CSSLink.ReferrerPolicy }}"{{ end }}{{ if .CSSLink.Title }} title="{{ .CSSLink.Title }}"{{ end }}{{ if .CSSLink.Type }} type="{{ .CSSLink.Type }}"{{ end }}{{ range $key, $val := .CSSLink.Attrs }} {{ $key }}="{{ $val }}"{{ end }}>`, nil
+}
+
+// getKey returns a cache key for the template for this tag. The cache key
+// should be unique to the template literal, without regard to the template
+// data.
+func (tag CSSLink) getKey() string {
+	if tag.TemplatePath != "" {
+		return tag.TemplatePath
+	}
+	return ":::impractical.co/temple:defaultCSSLinkTemplate"
+}
 
 // CSSEmbedder is an interface that Components can fulfill to include some CSS
 // that should be embedded directly into the rendered HTML. The contents will
-// be made available to the template as .EmbeddedCSS.
+// be made available to the template as .CSS.
 type CSSEmbedder interface {
-	// EmbedCSS returns the CSS, without <style> tags, that should be
-	// embedded directly in the output HTML.
-	//
-	// If this Component embeds any other Components, it should include
-	// their EmbedCSS output in its own EmbedCSS output.
-	EmbedCSS(context.Context) template.CSS
+	// EmbedCSS returns the CSSInline values that describe the CSS to embed
+	// directly in the output HTML.
+	EmbedCSS(context.Context) []CSSInline
 }
 
 // CSSLinker is an interface that Components can fulfill to include some CSS
 // that should be loaded through a <link> element in the template. The contents
-// will be made available to the template as .LinkedCSS.
+// will be made available to the template as .CSS.
 type CSSLinker interface {
-	// LinkCSS returns a list of URLs to CSS files that should be linked to
-	// from the output HTML.
-	//
-	// If this Component embeds any other Components, it should include
-	// their LinkCSS output in its own LinkCSS output.
-	LinkCSS(context.Context) []string
-}
-
-func getComponentCSSEmbeds(ctx context.Context, component Component) template.CSS {
-	var results template.CSS
-	seen := map[string]struct{}{}
-	components := getRecursiveComponents(ctx, component)
-	for _, comp := range components {
-		embed, ok := comp.(CSSEmbedder)
-		if !ok {
-			continue
-		}
-		css := embed.EmbedCSS(ctx)
-		checksum := hex.EncodeToString(sha256.New().Sum([]byte(css)))
-		if _, ok := seen[checksum]; ok {
-			continue
-		}
-		seen[checksum] = struct{}{}
-		results += template.CSS(fmt.Sprintf(`
-/* embedded CSS from %T */
-%s`, comp, css)) // #nosec G203
-	}
-	return results
-}
-
-func getComponentCSSLinks(ctx context.Context, component Component) []string {
-	var results []string
-	seen := map[string]struct{}{}
-	components := getRecursiveComponents(ctx, component)
-	for _, comp := range components {
-		link, ok := comp.(CSSLinker)
-		if !ok {
-			continue
-		}
-		css := link.LinkCSS(ctx)
-		for _, source := range css {
-			if _, ok := seen[source]; ok {
-				continue
-			}
-			results = append(results, source)
-			seen[source] = struct{}{}
-		}
-	}
-	return results
+	// LinkCSS returns a list of CSSLink values that describe the CSS links
+	// to include in the output HTML.
+	LinkCSS(context.Context) []CSSLink
 }

--- a/dag.go
+++ b/dag.go
@@ -1,0 +1,505 @@
+package temple
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+)
+
+var (
+	// ErrResourceCycle is returned when a dependency cycle between
+	// resources is found. This should never happen; it means that the
+	// resource another resource depends on itself depends on that other
+	// resource. It always indicates a misconfiguration of the resource
+	// dependency graph, and means that the ResourceRelationship returned
+	// from the RelationCalculator property on a struct is problematic.
+	ErrResourceCycle = errors.New("resource cycle detected")
+)
+
+// graph is a directed acyclic graph of type Type. It's used to ensure ordering
+// constraints of CSS and JS assets are met.
+type graph[Type any] struct {
+	// nodes holds the nodes in the graph.
+	nodes []Type
+
+	// edgesTo holds graph edges, with the key being the position of the
+	// node in the nodes slice that the edges are pointing to. It is a list
+	// of edges indexed by what they're pointing to.
+	//
+	// if there's a node 1 and a node 2, and an edge from 1->2, edgesTo
+	// will have a key of 2 with a value of [1].
+	//
+	// nodes point to their dependencies and dependencies are always
+	// walked first; i.e., if there's a node 1 and a node 2, and an edge
+	// from 1->2, 2 will always appear before 1 when walking the graph.
+	edgesTo map[int]map[int]struct{}
+
+	// edgesFrom holds graph edges, with the key being the position of the
+	// node in the nodes slice that the edges are pointing from. It is a
+	// list of edges indexed by what's doing the pointing.
+	//
+	// if there's a node 1 and a node 2, and an edge from 1->2, edgesFrom
+	// will have a key of 1 with a value of [2].
+	//
+	// nodes point to their dependencies and dependencies are always
+	// walked first; i.e., if there's a node 1 and a node 2, and an edge
+	// from 1->2, 2 will always appear before 1 when walking the graph.
+	edgesFrom map[int]map[int]struct{}
+}
+
+// resourceGraphs is a collection of graphs, one for CSS resources, one for
+// JavaScript resources that should be included in the page header, and one for
+// JavaScript resources that should be included in the page footer.
+type resourceGraphs struct {
+	css    graph[cssResource]
+	headJS graph[jsResource]
+	footJS graph[jsResource]
+}
+
+// buildGraphs creates a resourceGraphs containing all the resources that the
+// passed components define, with all their dependencies computed.
+//
+// Each component's resources will have an implicit dependency on the previous
+// resource of their type for that component, so their order within the slice
+// will be preserved when rendering them.
+func buildGraphs(ctx context.Context, components []Component) resourceGraphs {
+	result := resourceGraphs{
+		css: graph[cssResource]{
+			edgesTo:   map[int]map[int]struct{}{},
+			edgesFrom: map[int]map[int]struct{}{},
+		},
+		headJS: graph[jsResource]{
+			edgesTo:   map[int]map[int]struct{}{},
+			edgesFrom: map[int]map[int]struct{}{},
+		},
+		footJS: graph[jsResource]{
+			edgesTo:   map[int]map[int]struct{}{},
+			edgesFrom: map[int]map[int]struct{}{},
+		},
+	}
+	for _, component := range components {
+		if cssLinker, ok := component.(CSSLinker); ok {
+			links := cssLinker.LinkCSS(ctx)
+			lastLink := -1
+			for _, link := range links {
+				if slices.ContainsFunc(result.css.nodes, func(existing cssResource) bool {
+					return link.equal(existing)
+				}) {
+					continue
+				}
+				result.css.nodes = append(result.css.nodes, link)
+				thisNode := len(result.css.nodes) - 1
+				if lastLink >= 0 {
+					if result.css.edgesFrom[thisNode] == nil {
+						result.css.edgesFrom[thisNode] = map[int]struct{}{}
+					}
+					if result.css.edgesTo[lastLink] == nil {
+						result.css.edgesTo[lastLink] = map[int]struct{}{}
+					}
+					result.css.edgesFrom[thisNode][lastLink] = struct{}{}
+					result.css.edgesTo[lastLink][thisNode] = struct{}{}
+				}
+				lastLink = thisNode
+			}
+		}
+		if cssEmbedder, ok := component.(CSSEmbedder); ok {
+			blocks := cssEmbedder.EmbedCSS(ctx)
+			lastBlock := -1
+			for _, block := range blocks {
+				if slices.ContainsFunc(result.css.nodes, func(existing cssResource) bool {
+					return block.equal(existing)
+				}) {
+					continue
+				}
+				result.css.nodes = append(result.css.nodes, block)
+				thisNode := len(result.css.nodes) - 1
+				if lastBlock >= 0 {
+					if result.css.edgesFrom[thisNode] == nil {
+						result.css.edgesFrom[thisNode] = map[int]struct{}{}
+					}
+					if result.css.edgesTo[lastBlock] == nil {
+						result.css.edgesTo[lastBlock] = map[int]struct{}{}
+					}
+					result.css.edgesFrom[thisNode][lastBlock] = struct{}{}
+					result.css.edgesTo[lastBlock][thisNode] = struct{}{}
+				}
+				lastBlock = thisNode
+			}
+		}
+		if jsLinker, ok := component.(JSLinker); ok {
+			links := jsLinker.LinkJS(ctx)
+			lastHeadLink, lastFootLink := -1, -1
+			for _, link := range links {
+				if link.PlaceInFooter {
+					if slices.ContainsFunc(result.footJS.nodes, func(existing jsResource) bool {
+						return link.equal(existing)
+					}) {
+						continue
+					}
+					result.footJS.nodes = append(result.footJS.nodes, link)
+					thisNode := len(result.footJS.nodes) - 1
+					if lastFootLink >= 0 {
+						if result.footJS.edgesFrom[thisNode] == nil {
+							result.footJS.edgesFrom[thisNode] = map[int]struct{}{}
+						}
+						if result.footJS.edgesTo[lastFootLink] == nil {
+							result.footJS.edgesTo[lastFootLink] = map[int]struct{}{}
+						}
+						result.footJS.edgesFrom[thisNode][lastFootLink] = struct{}{}
+						result.footJS.edgesTo[lastFootLink][thisNode] = struct{}{}
+					}
+					lastFootLink = thisNode
+				} else {
+					if slices.ContainsFunc(result.headJS.nodes, func(existing jsResource) bool {
+						return link.equal(existing)
+					}) {
+						continue
+					}
+					result.headJS.nodes = append(result.headJS.nodes, link)
+					thisNode := len(result.headJS.nodes) - 1
+					if lastHeadLink >= 0 {
+						if result.headJS.edgesFrom[thisNode] == nil {
+							result.headJS.edgesFrom[thisNode] = map[int]struct{}{}
+						}
+						if result.headJS.edgesTo[lastHeadLink] == nil {
+							result.headJS.edgesTo[lastHeadLink] = map[int]struct{}{}
+						}
+						result.headJS.edgesFrom[thisNode][lastHeadLink] = struct{}{}
+						result.headJS.edgesTo[lastHeadLink][thisNode] = struct{}{}
+					}
+					lastHeadLink = thisNode
+				}
+			}
+		}
+		if jsEmbedder, ok := component.(JSEmbedder); ok {
+			blocks := jsEmbedder.EmbedJS(ctx)
+			lastHeadBlock, lastFootBlock := -1, -1
+			for _, block := range blocks {
+				if block.PlaceInFooter {
+					if slices.ContainsFunc(result.footJS.nodes, func(existing jsResource) bool {
+						return block.equal(existing)
+					}) {
+						continue
+					}
+					result.footJS.nodes = append(result.footJS.nodes, block)
+					thisNode := len(result.footJS.nodes) - 1
+					if lastFootBlock >= 0 {
+						if result.footJS.edgesFrom[thisNode] == nil {
+							result.footJS.edgesFrom[thisNode] = map[int]struct{}{}
+						}
+						if result.footJS.edgesTo[lastFootBlock] == nil {
+							result.footJS.edgesTo[lastFootBlock] = map[int]struct{}{}
+						}
+						result.footJS.edgesFrom[thisNode][lastFootBlock] = struct{}{}
+						result.footJS.edgesTo[lastFootBlock][thisNode] = struct{}{}
+					}
+					lastFootBlock = thisNode
+				} else {
+					if slices.ContainsFunc(result.headJS.nodes, func(existing jsResource) bool {
+						return block.equal(existing)
+					}) {
+						continue
+					}
+					result.headJS.nodes = append(result.headJS.nodes, block)
+					thisNode := len(result.headJS.nodes) - 1
+					if lastHeadBlock >= 0 {
+						if result.headJS.edgesFrom[thisNode] == nil {
+							result.headJS.edgesFrom[thisNode] = map[int]struct{}{}
+						}
+						if result.headJS.edgesTo[lastHeadBlock] == nil {
+							result.headJS.edgesTo[lastHeadBlock] = map[int]struct{}{}
+						}
+						result.headJS.edgesFrom[thisNode][lastHeadBlock] = struct{}{}
+						result.headJS.edgesTo[lastHeadBlock][thisNode] = struct{}{}
+					}
+					lastHeadBlock = thisNode
+				}
+			}
+		}
+	}
+	for pos, resource := range result.css.nodes {
+		var linkComparer func(context.Context, CSSLink) ResourceRelationship
+		var inlineComparer func(context.Context, CSSInline) ResourceRelationship
+		switch res := resource.(type) {
+		case CSSInline:
+			linkComparer = res.CSSLinkRelationCalculator
+			inlineComparer = res.CSSInlineRelationCalculator
+		case CSSLink:
+			linkComparer = res.CSSLinkRelationCalculator
+			inlineComparer = res.CSSInlineRelationCalculator
+		}
+		if linkComparer == nil && inlineComparer == nil {
+			continue
+		}
+		for compPos, comparison := range result.css.nodes {
+			rel := ResourceRelationshipNeutral
+			switch comp := comparison.(type) {
+			case CSSInline:
+				if inlineComparer == nil {
+					continue
+				}
+				rel = inlineComparer(ctx, comp)
+			case CSSLink:
+				if linkComparer == nil {
+					continue
+				}
+				rel = linkComparer(ctx, comp)
+			}
+			switch rel {
+			case ResourceRelationshipAfter:
+				if result.css.edgesFrom[pos] == nil {
+					result.css.edgesFrom[pos] = map[int]struct{}{}
+				}
+				if result.css.edgesTo[compPos] == nil {
+					result.css.edgesTo[compPos] = map[int]struct{}{}
+				}
+				result.css.edgesFrom[pos][compPos] = struct{}{}
+				result.css.edgesTo[compPos][pos] = struct{}{}
+			case ResourceRelationshipBefore:
+				if result.css.edgesFrom[compPos] == nil {
+					result.css.edgesFrom[compPos] = map[int]struct{}{}
+				}
+				if result.css.edgesTo[pos] == nil {
+					result.css.edgesTo[pos] = map[int]struct{}{}
+				}
+				result.css.edgesFrom[compPos][pos] = struct{}{}
+				result.css.edgesTo[pos][compPos] = struct{}{}
+			case ResourceRelationshipNeutral:
+				// do nothing, this doesn't imply dependency
+			}
+		}
+	}
+	for pos, resource := range result.headJS.nodes {
+		var linkComparer func(context.Context, JSLink) ResourceRelationship
+		var inlineComparer func(context.Context, JSInline) ResourceRelationship
+		switch res := resource.(type) {
+		case JSInline:
+			linkComparer = res.JSLinkRelationCalculator
+			inlineComparer = res.JSInlineRelationCalculator
+		case JSLink:
+			linkComparer = res.JSLinkRelationCalculator
+			inlineComparer = res.JSInlineRelationCalculator
+		}
+		if linkComparer == nil && inlineComparer == nil {
+			continue
+		}
+		for compPos, comparison := range result.headJS.nodes {
+			rel := ResourceRelationshipNeutral
+			switch comp := comparison.(type) {
+			case JSInline:
+				rel = inlineComparer(ctx, comp)
+			case JSLink:
+				rel = linkComparer(ctx, comp)
+			}
+			switch rel {
+			case ResourceRelationshipAfter:
+				if result.headJS.edgesFrom[pos] == nil {
+					result.headJS.edgesFrom[pos] = map[int]struct{}{}
+				}
+				if result.headJS.edgesTo[compPos] == nil {
+					result.headJS.edgesTo[compPos] = map[int]struct{}{}
+				}
+				result.headJS.edgesFrom[pos][compPos] = struct{}{}
+				result.headJS.edgesTo[compPos][pos] = struct{}{}
+			case ResourceRelationshipBefore:
+				if result.headJS.edgesFrom[compPos] == nil {
+					result.headJS.edgesFrom[compPos] = map[int]struct{}{}
+				}
+				if result.headJS.edgesTo[pos] == nil {
+					result.headJS.edgesTo[pos] = map[int]struct{}{}
+				}
+				result.headJS.edgesFrom[compPos][pos] = struct{}{}
+				result.headJS.edgesTo[pos][compPos] = struct{}{}
+			case ResourceRelationshipNeutral:
+				// do nothing, this doesn't imply dependency
+			}
+		}
+	}
+	for pos, resource := range result.footJS.nodes {
+		var linkComparer func(context.Context, JSLink) ResourceRelationship
+		var inlineComparer func(context.Context, JSInline) ResourceRelationship
+		switch res := resource.(type) {
+		case JSInline:
+			linkComparer = res.JSLinkRelationCalculator
+			inlineComparer = res.JSInlineRelationCalculator
+		case JSLink:
+			linkComparer = res.JSLinkRelationCalculator
+			inlineComparer = res.JSInlineRelationCalculator
+		}
+		if linkComparer == nil && inlineComparer == nil {
+			continue
+		}
+		for compPos, comparison := range result.footJS.nodes {
+			rel := ResourceRelationshipNeutral
+			switch comp := comparison.(type) {
+			case JSInline:
+				rel = inlineComparer(ctx, comp)
+			case JSLink:
+				rel = linkComparer(ctx, comp)
+			}
+			switch rel {
+			case ResourceRelationshipAfter:
+				if result.footJS.edgesFrom[pos] == nil {
+					result.footJS.edgesFrom[pos] = map[int]struct{}{}
+				}
+				if result.footJS.edgesTo[compPos] == nil {
+					result.footJS.edgesTo[compPos] = map[int]struct{}{}
+				}
+				result.footJS.edgesFrom[pos][compPos] = struct{}{}
+				result.footJS.edgesTo[compPos][pos] = struct{}{}
+			case ResourceRelationshipBefore:
+				if result.footJS.edgesFrom[compPos] == nil {
+					result.footJS.edgesFrom[compPos] = map[int]struct{}{}
+				}
+				if result.footJS.edgesTo[pos] == nil {
+					result.footJS.edgesTo[pos] = map[int]struct{}{}
+				}
+				result.footJS.edgesFrom[compPos][pos] = struct{}{}
+				result.footJS.edgesTo[pos][compPos] = struct{}{}
+			case ResourceRelationshipNeutral:
+				// do nothing, this doesn't imply dependency
+			}
+		}
+	}
+	return result
+}
+
+func sortNodesByPos[Node any](nodes []Node, a, b int) int {
+	return sortNodes(nodes[a], nodes[b])
+}
+
+func sortNodes[Node any](first, second Node) int {
+	switch firstNode := any(first).(type) {
+	case CSSInline:
+		switch secondNode := any(second).(type) {
+		case CSSInline:
+			firstKey := firstNode.getKey()
+			secondKey := secondNode.getKey()
+			if firstKey < secondKey {
+				return -1
+			}
+			if secondKey < firstKey {
+				return 1
+			}
+			return 0
+		case CSSLink:
+			return 1
+		default:
+			panic(fmt.Sprintf("unexpected type %T when sorting CSS resources", second))
+		}
+	case CSSLink:
+		switch secondNode := any(second).(type) {
+		case CSSInline:
+			return -1
+		case CSSLink:
+			if firstNode.Href < secondNode.Href {
+				return -1
+			}
+			if secondNode.Href < firstNode.Href {
+				return 1
+			}
+			return 0
+		default:
+			panic(fmt.Sprintf("unexpected type %T when sorting CSS resources", second))
+		}
+	case JSInline:
+		switch secondNode := any(second).(type) {
+		case JSInline:
+			firstKey := firstNode.getKey()
+			secondKey := secondNode.getKey()
+			if firstKey < secondKey {
+				return -1
+			}
+			if secondKey < firstKey {
+				return 1
+			}
+			return 0
+		case JSLink:
+			return 1
+		default:
+			panic(fmt.Sprintf("unexpected type %T when sorting JavaScript resources", second))
+		}
+	case JSLink:
+		switch secondNode := any(second).(type) {
+		case JSInline:
+			return -1
+		case JSLink:
+			if firstNode.Src < secondNode.Src {
+				return -1
+			}
+			if secondNode.Src < firstNode.Src {
+				return 1
+			}
+			return 0
+		default:
+			panic(fmt.Sprintf("unexpected type %T when sorting JavaScript resources", second))
+		}
+	default:
+		panic(fmt.Sprintf("unexpected type %T when sorting resources", first))
+	}
+}
+
+func walkGraph[Node any](_ context.Context, resources graph[Node]) ([]Node, error) {
+	noParents := make([]int, 0, len(resources.nodes))
+	results := make([]Node, 0, len(resources.nodes))
+	for pos := range resources.nodes {
+		edges, ok := resources.edgesFrom[pos]
+		if !ok {
+			noParents = append(noParents, pos)
+			continue
+		}
+		if len(edges) < 1 {
+			noParents = append(noParents, pos)
+			continue
+		}
+	}
+	slices.SortFunc(noParents, func(a, b int) int {
+		return sortNodesByPos(resources.nodes, a, b)
+	})
+	for len(noParents) > 0 {
+		pos := noParents[0]
+		node := resources.nodes[pos]
+		noParents = noParents[1:]
+		results = append(results, node)
+		var noParentsChanged bool
+		for child := range resources.edgesTo[pos] {
+			delete(resources.edgesFrom[child], pos)
+			delete(resources.edgesTo[pos], child)
+			if len(resources.edgesFrom[child]) < 1 {
+				delete(resources.edgesFrom, child)
+				noParents = append(noParents, child)
+				noParentsChanged = true
+			}
+			if len(resources.edgesTo[pos]) < 1 {
+				delete(resources.edgesTo, pos)
+			}
+		}
+		if noParentsChanged {
+			slices.SortFunc(noParents, func(a, b int) int {
+				return sortNodesByPos(resources.nodes, a, b)
+			})
+		}
+	}
+	if len(resources.edgesTo) > 0 || len(resources.edgesFrom) > 0 {
+		var edgesTo, edgesFrom []string
+		for k, v := range resources.edgesTo {
+			var vals []string
+			for val := range v {
+				vals = append(vals, strconv.Itoa(val))
+			}
+			edgesTo = append(edgesTo, fmt.Sprintf("%d:%s", k, strings.Join(vals, ",")))
+		}
+		for k, v := range resources.edgesFrom {
+			var vals []string
+			for val := range v {
+				vals = append(vals, strconv.Itoa(val))
+			}
+			edgesFrom = append(edgesFrom, fmt.Sprintf("%d:%s", k, strings.Join(vals, ",")))
+		}
+		return results, fmt.Errorf("%w: edges_to=[%s], edges_from=[%s]", ErrResourceCycle, strings.Join(edgesTo, "; "), strings.Join(edgesFrom, "; "))
+	}
+	return results, nil
+}

--- a/example_basic_test.go
+++ b/example_basic_test.go
@@ -38,6 +38,12 @@ func (h HomePage) ExecutedTemplate(_ context.Context) string {
 	return h.Layout.BaseTemplate()
 }
 
+func (HomePage) EmbedCSS(_ context.Context) []temple.CSSInline {
+	return []temple.CSSInline{
+		{TemplatePath: "home.css.tmpl"},
+	}
+}
+
 type BaseLayout struct {
 }
 
@@ -59,11 +65,13 @@ func ExampleRender_basic() {
 <html lang="en">
 	<head>
 		<title>{{ .Site.Title }}</title>
+		{{ .CSS }}
 	</head>
 	<body>
 		{{ block "body" . }}{{ end }}
 	</body>
 </html>`,
+		"home.css.tmpl": "body { font: red; }",
 	}
 
 	// usually the context comes from the request, but here we're building it from scratch and adding a logger
@@ -81,6 +89,10 @@ func ExampleRender_basic() {
 	// <html lang="en">
 	// 	<head>
 	// 		<title>My Example Site</title>
+	// 		<style>
+	// body { font: red; }
+	// </style>
+	//
 	// 	</head>
 	// 	<body>
 	// 		Hello, world. This is my home page.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module impractical.co/temple
 
-go 1.21
+go 1.23
 
 require (
 	go.opentelemetry.io/otel v1.28.0

--- a/js.go
+++ b/js.go
@@ -2,73 +2,462 @@ package temple
 
 import (
 	"context"
-	"crypto/sha256"
-	"encoding/hex"
-	"fmt"
-	"html/template"
+	"errors"
+	"io/fs"
+	"maps"
+	"strings"
 )
+
+var (
+	// ErrJSInlineTemplatePathNotSet is returned when the TemplatePath
+	// property on a JSInline is not set, which isn't valid. The
+	// TemplatePath controls what JavaScript to embed, so it should never
+	// be omitted.
+	ErrJSInlineTemplatePathNotSet = errors.New("JSInline TemplatePath must be set")
+)
+
+// jsResource is an abstraction over JSLink and JSInline.
+type jsResource interface {
+	// getJS returns the JS template string to render for the link or
+	// script block.
+	getJS(dir fs.FS) (string, error)
+
+	// getKey returns a unique identifier for the template, used when
+	// caching it.
+	getKey() string
+
+	// equal should return true if the passed jsResource is considered
+	// equivalent to the implementing jsResource. This is used when
+	// deduplicating resources.
+	equal(jsResource) bool
+}
+
+// JSRenderData holds the information passed to the template when rendering the
+// template for a [JSInline] or [JSLink].
+type JSRenderData[SiteType Site, PageType Renderable] struct {
+	// JS is the JSInline struct being rendered. It may be empty if this
+	// data is for a JSLink instead.
+	JS JSInline
+
+	// JSLink is the JSLink struct being rendered. It may be empty if this
+	// data is for a JSInline instead.
+	JSLink JSLink
+
+	// Site is the caller-defined site type, used for including globals.
+	Site SiteType
+
+	// Page is the specific page the JS is being rendered into.
+	Page PageType
+}
+
+// JSInline holds the necessary information to embed JavaScript directly into a
+// page's HTML output, inside a <script> tag.
+//
+// The TemplatePath should point to a template containing the JavaScript to
+// render. The template can use any of the data in the [JSRenderData]. The
+// <script> tag should not be included; it will be generated from the rest of
+// the properties.
+//
+// temple may, but is not guaranteed to, merge <script> blocks it identifies as
+// mergeable. At the moment, those merge semantics are that all properties
+// except the relation calculators are identical, but that logic is subject to
+// change. If it is important that a <script> block not be merged into any
+// other <script> block, set DisableElementMerge to true.
+type JSInline struct {
+	// TemplatePath is the path, relative to the Site's TemplateDir, to the
+	// template that should be rendered to get the contents of the
+	// JavaScript <script> tag. The template should not include the
+	// <script> tags. A JSRenderData value will be passed as the template
+	// data, with the JSInline property set to this value.
+	TemplatePath string
+
+	// CrossOrigin is the value of the crossorigin attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin
+	// for more information.
+	CrossOrigin string
+
+	// NoModule indicates whether to include the nomodule attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#nomodule
+	// for more information.
+	NoModule bool
+
+	// Nonce is the value of the nonce attribute for the <script> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#nonce
+	// for more information.
+	Nonce string
+
+	// ReferrerPolicy is the value of the referrerpolicy attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#referrerpolicy
+	// for more information.
+	ReferrerPolicy string
+
+	// Type is the value of the type attribute for the <script> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#type
+	// for more information.
+	Type string
+
+	// Attrs holds any additional non-standard or unsupported attributes
+	// that should be set on the <script> tag that will be generated.
+	Attrs map[string]string
+
+	// DisableElementMerge, when set to true, prevents a <script> tag from
+	// being merged with any other <script> tag.
+	DisableElementMerge bool
+
+	// PlaceInFooter, when set to true, makes this JavaScript part of the
+	// FooterJS property of RenderData. Otherwise, it is part of the
+	// HeaderJS property of RenderData. This separation exists so some
+	// JavaScript can be loaded in the <head> of the document, while other
+	// JavaScript can be loaded after the rest of the document has been
+	// loaded. Where these properties end up actually being placed is up to
+	// the template, but that is the intention.
+	PlaceInFooter bool
+
+	// JSInlineRelationCalculator can be used to control how this <script>
+	// tag gets rendered in relation to any other <script> tag. If the
+	// function returns ResourceRelationshipAfter, this <script> tag will
+	// always come after the other <script> tag in the HTML document. If
+	// the function returns ResourceRelationshipBefore, this <script> tag
+	// will always come before the other <script> tag in the HTML document.
+	// If the function returns ResourceRelationshipNeutral, no guarantees
+	// are made about where the JavaScript resources will appear relative
+	// to each other in the HTML document.
+	//
+	// If this <script> tag has no requirements about its positioning
+	// relative to other JavaScript resources, just let this property be
+	// nil.
+	JSInlineRelationCalculator func(context.Context, JSInline) ResourceRelationship
+
+	// JSLinkRelationCalculator can be used to control how this <script> tag
+	// gets rendered in relation to any other JavaScript <script> tag. If the
+	// function returns ResourceRelationshipAfter, this <script> tag will
+	// always come after the other <script> tag in the HTML document. If the
+	// function returns ResourceRelationshipBefore, this <script> tag will
+	// always come before the other <script> tag in the HTML document. If the
+	// function returns ResourceRelationshipNeutral, no guarantees are made
+	// about where the JavaScript resources will appear relative to each other in
+	// the HTML document.
+	//
+	// These orderings are only guaranteed when comparing resources with
+	// the same PlaceInFooter values.
+	//
+	// If this <script> tag has no requirements about its positioning
+	// relative to other JavaScript resources, just let this property be nil.
+	JSLinkRelationCalculator func(context.Context, JSLink) ResourceRelationship
+}
+
+// getJS returns the string to include in the JavaScript output, using the
+// passed fs.FS to load the template path.
+func (block JSInline) getJS(dir fs.FS) (string, error) {
+	if strings.TrimSpace(block.TemplatePath) == "" {
+		return "", ErrJSInlineTemplatePathNotSet
+	}
+	contents, err := fs.ReadFile(dir, block.TemplatePath)
+	if err != nil {
+		return "", err
+	}
+	typestring := block.Type
+	if typestring != "" {
+		typestring = ` type="` + typestring + `"`
+	}
+	return `<script` + typestring + `{{if .JS.CrossOrigin }} crossorigin="{{ .JS.CrossOrigin }}"{{ end }}{{ if .JS.NoModule }} nomodule{{ end }}{{ if .JS.Nonce }} nonce="{{.Nonce}}"{{ end }}{{ if .JS.ReferrerPolicy }} referrerpolicy="{{ .JS.ReferrerPolicy }}"{{ end }}{{ range $k, $v := .JS.Attrs }}{{ $k }}{{ if $v }}="{{$v}}"{{ end }}{{ end }}>
+` + string(contents) + `
+</script>`, nil
+}
+
+// getKey returns a cache key for the template for this tag. The cache key
+// should be unique to the template literal, without regard to the template
+// data.
+func (block JSInline) getKey() string {
+	return block.TemplatePath
+}
+
+// equal returns true if block and other should be considered equal. The
+// largest consequence of returning true is that only one will be rendered to
+// the page.
+func (block JSInline) equal(other jsResource) bool {
+	comp, ok := other.(JSInline)
+	if !ok {
+		return false
+	}
+	if block.TemplatePath != comp.TemplatePath {
+		return false
+	}
+	if block.CrossOrigin != comp.CrossOrigin {
+		return false
+	}
+	if block.NoModule != comp.NoModule {
+		return false
+	}
+	if block.Nonce != comp.Nonce {
+		return false
+	}
+	if block.ReferrerPolicy != comp.ReferrerPolicy {
+		return false
+	}
+	if block.Type != comp.Type {
+		return false
+	}
+	if !maps.Equal(block.Attrs, comp.Attrs) {
+		return false
+	}
+	if block.DisableElementMerge != comp.DisableElementMerge {
+		return false
+	}
+	if block.PlaceInFooter != comp.PlaceInFooter {
+		return false
+	}
+	return true
+}
+
+// JSLink holds the necessary information to include JavaScript in a page's
+// HTML output as a <script> with a src attribute that downloads the JavaScript
+// file from another URL.
+//
+// The Src should point to the URL to load the JavaScript file from.
+type JSLink struct {
+	// Src is the URL to load the JavaScript from. It will be used verbatim
+	// as the <script> element's src attribute. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#src
+	// for more information.
+	Src string
+
+	// Async indicates whether to include the async attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#async
+	// for more information.
+	Async bool
+
+	// AttributionSrc, if set to true, will include the attributionsrc
+	// attribute in the <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#attributionsrc
+	// for more information.
+	AttributionSrc bool
+
+	// AttributionSrcURLs, if non-empty, will set the value of the
+	// attributionsrc attribute in the <script> tag that will be generated.
+	// See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#attributionsrc
+	// for more information.
+	//
+	// If AttributionSrcURLs is set, AttributionSrc must be set to true, or
+	// AttributionSrcURLs will have no effect.
+	AttributionSrcURLs string
+
+	// Blocking is the value of the blocking attribute for the <script> tag
+	// that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#blocking
+	// for more information.
+	Blocking string
+
+	// CrossOrigin is the value of the crossorigin attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#crossorigin
+	// for more information.
+	CrossOrigin string
+
+	// Defer indicates whether to include the defer attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#defer
+	// for more information.
+	Defer bool
+
+	// FetchPriority is the value of the fetchpriority attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#fetchpriority
+	// for more information.
+	FetchPriority string
+
+	// Integrity is the value of the integrity attribute for the <script>
+	// tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#integrity
+	// for more information.
+	Integrity string
+
+	// NoModule indicates whether to include the nomodule attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#nomodule
+	// for more information.
+	NoModule bool
+
+	// Nonce is the value of the nonce attribute for the <script> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#nonce
+	// for more information.
+	Nonce string
+
+	// ReferrerPolicy is the value of the referrerpolicy attribute for the
+	// <script> tag that will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#referrerpolicy
+	// for more information.
+	ReferrerPolicy string
+
+	// Type is the value of the type attribute for the <script> tag that
+	// will be generated. See
+	// https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/script#type
+	// for more information.
+	Type string
+
+	// Attrs holds any additional non-standard or unsupported attributes
+	// that should be set on the <script> tag that will be generated.
+	Attrs map[string]string
+
+	// TemplatePath is the path, relative to the Site's TemplateDir, to the
+	// template that should be rendered to construct the <script> tag from
+	// this struct. If left empty, the default template will be used, but
+	// it can be specified to override the template if desired. A
+	// JSRenderData will be passed to the template with the JSLink property
+	// set.
+	TemplatePath string
+
+	// PlaceInFooter, when set to true, makes this JavaScript part of the
+	// FooterJS property of RenderData. Otherwise, it is part of the
+	// HeaderJS property of RenderData. This separation exists so some
+	// JavaScript can be loaded in the <head> of the document, while other
+	// JavaScript can be loaded after the rest of the document has been
+	// loaded. Where these properties end up actually being placed is up to
+	// the template, but that is the intention.
+	PlaceInFooter bool
+
+	// JSInlineRelationCalculator can be used to control how this <script>
+	// tag gets rendered in relation to any other <script> tag. If the
+	// function returns ResourceRelationshipAfter, this <script> tag will
+	// always come after the other <script> tag in the HTML document. If
+	// the function returns ResourceRelationshipBefore, this <script> tag
+	// will always come before the other <script> tag in the HTML document.
+	// If the function returns ResourceRelationshipNeutral, no guarantees
+	// are made about where the JavaScript resources will appear relative
+	// to each other in the HTML document.
+	//
+	// If this <script> tag has no requirements about its positioning
+	// relative to other JavaScript resources, just let this property be
+	// nil.
+	JSInlineRelationCalculator func(context.Context, JSInline) ResourceRelationship
+
+	// JSLinkRelationCalculator can be used to control how this <script> tag
+	// gets rendered in relation to any other JavaScript <script> tag. If the
+	// function returns ResourceRelationshipAfter, this <script> tag will
+	// always come after the other <script> tag in the HTML document. If the
+	// function returns ResourceRelationshipBefore, this <script> tag will
+	// always come before the other <script> tag in the HTML document. If the
+	// function returns ResourceRelationshipNeutral, no guarantees are made
+	// about where the JavaScript resources will appear relative to each other in
+	// the HTML document.
+	//
+	// These orderings are only guaranteed when comparing resources with
+	// the same PlaceInFooter values.
+	//
+	// If this <script> tag has no requirements about its positioning
+	// relative to other JavaScript resources, just let this property be nil.
+	JSLinkRelationCalculator func(context.Context, JSLink) ResourceRelationship
+}
+
+// equal returns true if tag and other should be considered equal. The largest
+// consequence of returning true is that only one will be rendered to the page.
+func (tag JSLink) equal(other jsResource) bool {
+	comp, ok := other.(JSLink)
+	if !ok {
+		return false
+	}
+	if tag.Src != comp.Src {
+		return false
+	}
+	if tag.Async != comp.Async {
+		return false
+	}
+	if tag.AttributionSrc != comp.AttributionSrc {
+		return false
+	}
+	if tag.AttributionSrcURLs != comp.AttributionSrcURLs {
+		return false
+	}
+	if tag.Blocking != comp.Blocking {
+		return false
+	}
+	if tag.CrossOrigin != comp.CrossOrigin {
+		return false
+	}
+	if tag.Defer != comp.Defer {
+		return false
+	}
+	if tag.FetchPriority != comp.FetchPriority {
+		return false
+	}
+	if tag.Integrity != comp.Integrity {
+		return false
+	}
+	if tag.NoModule != comp.NoModule {
+		return false
+	}
+	if tag.Nonce != comp.Nonce {
+		return false
+	}
+	if tag.ReferrerPolicy != comp.ReferrerPolicy {
+		return false
+	}
+	if tag.Type != comp.Type {
+		return false
+	}
+	if !maps.Equal(tag.Attrs, comp.Attrs) {
+		return false
+	}
+	if tag.TemplatePath != comp.TemplatePath {
+		return false
+	}
+	if tag.PlaceInFooter != comp.PlaceInFooter {
+		return false
+	}
+	return true
+}
+
+// getJS returns the string to include in the JavaScript output, using the
+// passed fs.FS to load the template path, if tag.TemplatePath is set.
+func (tag JSLink) getJS(dir fs.FS) (string, error) {
+	if tag.TemplatePath != "" {
+		contents, err := fs.ReadFile(dir, tag.TemplatePath)
+		if err != nil {
+			return "", err
+		}
+		return string(contents), nil
+	}
+	return `<script{{ if .JSLink.Type }}type="{{ .JSLink.Type }}"{{ end }} src="{{ .JSLink.Src }}"{{ if .JSLink.Async }} async{{ end }}{{ if .JSLink.AttributionSrc }}attributionsrc{{if .JSLink.AttributionSrcURLs }}="{{ .JSLink.AttributionSrcURLs }}"{{ end }}{{ end }}{{ if .JSLink.Blocking }} blocking="{{ .JSLink.Blocking }}"{{ end }}{{if .JSLink.CrossOrigin }} crossorigin="{{ .JSLink.CrossOrigin }}"{{ end }}{{ if .JSLink.Defer }} defer{{ end }}{{ if .JSLink.FetchPriority }} fetchpriority="{{ .JSLink.FetchPriority }}"{{ end }}{{ if .JSLink.Integrity }} integrity="{{ .JSLink.Integrity }}"{{ end }}{{ if .JSLink.NoModule }} nomodule{{ end }}{{ if .JSLink.Nonce }} nonce="{{.Nonce}}"{{ end }}{{ if .JSLink.ReferrerPolicy }} referrerpolicy="{{ .JSLink.ReferrerPolicy }}"{{ end }}{{ range $k, $v := .JSLink.Attrs }} {{ $k }}{{ if $v }}="{{$v}}"{{ end }}{{ end }}></script>`, nil
+}
+
+// getKey returns a cache key for the template for this tag. The cache key
+// should be unique to the template literal, without regard to the template
+// data.
+func (tag JSLink) getKey() string {
+	if tag.TemplatePath != "" {
+		return tag.TemplatePath
+	}
+	return ":::impractical.co/temple:defaultJSLinkTemplate"
+}
 
 // JSEmbedder is an interface that Components can fulfill to include some
 // JavaScript that should be embedded directly into the rendered HTML. The
-// contents will be made available to the template as .EmbeddedJS.
+// contents will be made available to the template as .HeaderJS or .FooterJS,
+// depending on whether their PlaceInFooter property is set to true or not.
 type JSEmbedder interface {
 	// EmbedJS returns the JavaScript, without <script> tags, that should
 	// be embedded directly in the output HTML.
-	EmbedJS(context.Context) template.JS
+	EmbedJS(context.Context) []JSInline
 }
 
 // JSLinker is an interface that Components can fulfill to include some
 // JavaScript that should be loaded separately from the HTML document, using a
 // <script> tag with a src attribute. The contents will be made available to
-// the template as .LinkedJS.
+// the template as .HeaderJS or .FooterJS, depending on whether their
+// PlaceInFooter property is set to true or not.
 type JSLinker interface {
 	// LinkJS returns a list of URLs to JavaScript files that should be
 	// linked to from the output HTML.
 	//
 	// If this Component embeds any other Components, it should include
 	// their LinkJS output in its own LinkJS output.
-	LinkJS(context.Context) []string
-}
-
-func getComponentJSEmbeds(ctx context.Context, component Component) template.JS {
-	var results template.JS
-	seen := map[string]struct{}{}
-	components := getRecursiveComponents(ctx, component)
-	for _, comp := range components {
-		embed, ok := comp.(JSEmbedder)
-		if !ok {
-			continue
-		}
-		script := embed.EmbedJS(ctx)
-		checksum := hex.EncodeToString(sha256.New().Sum([]byte(script)))
-		if _, ok := seen[checksum]; ok {
-			continue
-		}
-		seen[checksum] = struct{}{}
-		results += template.JS(fmt.Sprintf(`
-/* embedded JavaScript from %T */
-%s`, comp, script)) // #nosec G203
-	}
-	return results
-}
-
-func getComponentJSLinks(ctx context.Context, component Component) []string {
-	var results []string
-	seen := map[string]struct{}{}
-	components := getRecursiveComponents(ctx, component)
-	for _, comp := range components {
-		link, ok := comp.(JSLinker)
-		if !ok {
-			continue
-		}
-		js := link.LinkJS(ctx)
-		for _, source := range js {
-			if _, ok := seen[source]; ok {
-				continue
-			}
-			results = append(results, source)
-			seen[source] = struct{}{}
-		}
-	}
-	return results
+	LinkJS(context.Context) []JSLink
 }

--- a/log.go
+++ b/log.go
@@ -31,6 +31,13 @@ func LoggingContext(ctx context.Context, logger *slog.Logger) context.Context {
 	return context.WithValue(ctx, slogCtxKey, logger)
 }
 
+// SetInLogger updates the slog.Logger embedded in the passed context.Context
+// to associate the passed keys and values with it. Any log lines temple prints
+// using the returned context.Context will include the passed keys and values.
+func SetInLogger(ctx context.Context, args ...any) context.Context {
+	return LoggingContext(ctx, logger(ctx).With(args...))
+}
+
 type noopHandler struct{}
 
 // Enabled always returns false for the noopHandler.

--- a/resource_rel.go
+++ b/resource_rel.go
@@ -1,0 +1,27 @@
+package temple
+
+// ResourceRelationship controls the relationship between two resources. It's
+// used to control the order in which CSS and JavaScript resources are rendered
+// to the page.
+type ResourceRelationship string
+
+const (
+	// ResourceRelationshipAfter indicates that the resource should be
+	// rendered after the resource it's being compared to.
+	ResourceRelationshipAfter ResourceRelationship = "after"
+
+	// ResourceRelationshipBefore indicates that the resource should be
+	// rendered before the resource it's being compared to.
+	ResourceRelationshipBefore ResourceRelationship = "before"
+
+	// ResourceRelationshipNeutral indicates that the resource has no
+	// restrictions about where it's rendered in relation to the resource
+	// it's being compared to. Generally, for performance reasons, it's
+	// preferred to omit the relationship calculation function entirely
+	// rather than returning a ResourceRelationshipNeutral value, but if
+	// the function could return other values when compared to other
+	// resources, ResourceRelationshipNeutral is necessary to be able to
+	// indicate that no relationship exists between these particular
+	// resources.
+	ResourceRelationshipNeutral ResourceRelationship = "neutral"
+)


### PR DESCRIPTION
When components rely on CSS or JS, sometimes they need to be included in specific orders. Define a Directed Acyclic Graph of the JavaScript resources and CSS resources we need, and render them in that order. Allow callers to customize the rendering order by declaring a relationship between two components. It is sufficient for either component to know about the other; both declaring the same dependency (i.e., A says it needs to be rendered before B, and B says it needs to be rendered after A) is harmless but not necessary.